### PR TITLE
Update HLS collection sql script

### DIFF
--- a/scripts/collections-sql/HLSS30.002.sql
+++ b/scripts/collections-sql/HLSS30.002.sql
@@ -45,7 +45,9 @@ INSERT INTO pgstac.collections (content) VALUES('{
    "properties": {
      "dashboard:is_periodic": true
      "dashboard:time_density": "hour",
-      
+     "summaries": {
+       "datetime": ["2021-07-29 01:00:00","2021-07-29 05:00:00Z"]
+     }
    }
 }')
 ON CONFLICT (id) DO UPDATE 

--- a/scripts/collections-sql/HLSS30.002.sql
+++ b/scripts/collections-sql/HLSS30.002.sql
@@ -4,6 +4,9 @@ INSERT INTO pgstac.collections (content) VALUES('{
    "links":[
    ],
    "title":"HLSS30.002",
+    
+   "dashboard:is_periodic": True,
+   "dashboard:time_density": 
    "extent":{
       "spatial":{
          "bbox":[
@@ -38,7 +41,12 @@ INSERT INTO pgstac.collections (content) VALUES('{
        "href": "https://cmr.earthdata.nasa.gov/search/concepts/C2021957295-LPCLOUD.html",
        "type": "text/html"
    }],
-   "stac_version":"1.0.0"
+   "stac_version":"1.0.0",
+   "properties": {
+     "dashboard:is_periodic": true
+     "dashboard:time_density": "hour",
+      
+   }
 }')
 ON CONFLICT (id) DO UPDATE 
   SET content = excluded.content;


### PR DESCRIPTION
Add properties to SQL script as per [conventions](https://github.com/NASA-IMPACT/delta-backend/issues/29)

Only adds `is_periodic` and `time_density`, and summaries. in summaries ive added the date range for what has been ingested so far... is this correct? Or should this be a list of all the records that had been ingested? In that case, seems like we would want to insert this collection with summaries empty and then populate it later.