### PR TITLE
Allow for multi assets.

### DIFF
--- a/lambdas/stac-gen/handler.py
+++ b/lambdas/stac-gen/handler.py
@@ -43,10 +43,22 @@ def upload_stac_to_s3(stac_dict):
         return None
 
 
-def create_item(properties, assets, datetime, cog_url, collection):
+def create_item(
+    properties,
+    assets,
+    datetime,
+    cog_url,
+    collection,
+    asset_name=None,
+    asset_roles=None,
+    asset_media_type=None
+):
     """
     Function to create a stac item from a COG using rio_stac
     """
+    asset_name = asset_name or ASSET_NAME
+    asset_roles = asset_roles or ASSET_ROLE
+    asset_media_type = asset_media_type or ASSET_MEDIA_TYPE
     try:
         item_id = Path(cog_url).stem
         rstac = create_stac_item(
@@ -60,9 +72,9 @@ def create_item(properties, assets, datetime, cog_url, collection):
             # TODO (aimee):
             # If we want to have multiple assets _and_ the raster stats from get_raster_info we need to make this conditional more flexible:
             # https://github.com/developmentseed/rio-stac/blob/0.3.2/rio_stac/stac.py#L315-L330
-            asset_name = "cog_default",
-            asset_roles = ["data", "layer"],
-            asset_media_type = "image/tiff; application=geotiff; profile=cloud-optimized",            
+            asset_name=asset_name,
+            asset_roles=asset_roles,
+            asset_media_type=asset_media_type,
         )
         print("Created item...")
     except Exception as e:

--- a/lambdas/stac-gen/handler.py
+++ b/lambdas/stac-gen/handler.py
@@ -1,19 +1,25 @@
-from cmr import GranuleQuery
-import os
+import boto3
 import json
-from pathlib import Path
+import os
 import pystac
-from pystac.utils import str_to_datetime
-from shapely.geometry import shape
-from pypgstac import pypgstac
-from rio_stac.stac import bbox_to_geom, create_stac_item
 import re
 import sys
-import boto3
+
+from cmr import GranuleQuery
+from pathlib import Path
+from pypgstac import pypgstac
+from pystac.utils import str_to_datetime
+from rio_stac.stac import bbox_to_geom, create_stac_item
+from shapely.geometry import shape
+
 
 s3 = boto3.client(
     "s3",
 )
+
+ASSET_NAME = "cog_default"
+ASSET_ROLE = ["data", "layer"]
+ASSET_MEDIA_TYPE = "image/tiff; application=geotiff; profile=cloud-optimized"
 
 STAC_DB_HOST = os.environ.get("STAC_DB_HOST")
 STAC_DB_USER = os.environ.get("STAC_DB_USER")

--- a/lambdas/stac-gen/handler.py
+++ b/lambdas/stac-gen/handler.py
@@ -116,6 +116,9 @@ def create_stac_item_with_cmr(event):
         datetime=dt,
         cog_url=cog_url,
         collection=collection,
+        asset_name=event.get("asset_name"),
+        asset_roles=event.get("asset_roles"),
+        asset_media_type=event.get("asset_media_type")
     )
     return stac_item
 

--- a/lambdas/stac-gen/handler.py
+++ b/lambdas/stac-gen/handler.py
@@ -179,6 +179,9 @@ def create_stac_item_with_regex(event):
         datetime=dt,
         cog_url=cog_url,
         collection=collection,
+        asset_name=event.get("asset_name"),
+        asset_roles=event.get("asset_roles"),
+        asset_media_type=event.get("asset_media_type")
     )
 
     return stac_item


### PR DESCRIPTION
# Issue:
Current implementation of the pipeline only supports "cog_default" and related information as asset type. This is not ideal for cases like blue-tarp which have multiple COGs related to them. 

# Changes:
1. Change import order following the IMPACT coding conventions.
2. Use variables instead of hard-coding the asset_name, type, and asset_media_type.